### PR TITLE
Inventory objects visuals fixed

### DIFF
--- a/Assets/Scenes/player_root.unity
+++ b/Assets/Scenes/player_root.unity
@@ -647,6 +647,11 @@ PrefabInstance:
       propertyPath: m_ForceIntoRT
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3343427492233289383, guid: 14acad5b4b0dd4043ab9e1b454769a51,
+        type: 3}
+      propertyPath: m_CullingMask.m_Bits
+      value: 823
+      objectReference: {fileID: 0}
     - target: {fileID: 3343427492233289401, guid: 14acad5b4b0dd4043ab9e1b454769a51,
         type: 3}
       propertyPath: m_Layer
@@ -1212,14 +1217,13 @@ GameObject:
   m_Component:
   - component: {fileID: 1835389366}
   - component: {fileID: 1835389368}
-  - component: {fileID: 1835389367}
   m_Layer: 0
   m_Name: Inventory Camera
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1835389366
 Transform:
   m_ObjectHideFlags: 0
@@ -1234,14 +1238,6 @@ Transform:
   m_Father: {fileID: 804111902}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!81 &1835389367
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1835389365}
-  m_Enabled: 1
 --- !u!20 &1835389368
 Camera:
   m_ObjectHideFlags: 0
@@ -1264,20 +1260,20 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
+  near clip plane: 0.01
+  far clip plane: 3
   field of view: 60
   orthographic: 0
   orthographic size: 5
   m_Depth: 1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 1
+    m_Bits: 2048
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
   m_TargetEye: 3
-  m_HDR: 0
+  m_HDR: 1
   m_AllowMSAA: 1
   m_AllowDynamicResolution: 0
   m_ForceIntoRT: 0

--- a/Assets/Scripts/Player/PickupObject.cs
+++ b/Assets/Scripts/Player/PickupObject.cs
@@ -70,7 +70,12 @@ public class PickupObject : MonoBehaviour
         }
         //FindAndSetOutlineMaterialForObj(false, o.item, false);
         //o.item.layer = 9;
-        o.item.gameObject.layer = 9;
+        Transform[] children = o.item.GetComponentsInChildren<Transform>();
+        foreach (Transform child in children)
+        {
+            child.gameObject.layer = 11;
+        }
+        //o.item.gameObject.layer = 11;
         o.item.transform.SetParent(this.transform);
         o.item.transform.SetParent(null);
         o.item.transform.position = Camera.main.ScreenToWorldPoint(pos);
@@ -229,7 +234,13 @@ public class PickupObject : MonoBehaviour
         FindAndSetOutlineMaterialForObj(true, currentlySelectedObj, false);
 
         GameObject obj = this.inventory.FindFirstObject();
-        currentlySelectedObj.layer = 0;
+
+        Transform[] children = currentlySelectedObj.GetComponentsInChildren<Transform>();
+        foreach (Transform child in children)
+        {
+            child.gameObject.layer = 0;
+        }
+
         if (obj)
         {
             FindAndSetOutlineMaterialForObj(false, obj, false);
@@ -284,7 +295,13 @@ public class PickupObject : MonoBehaviour
             //This piece of code adds the current item to the room its in instead of keeping it in the hands of the player
             //currentlySelectedObj.gameObject.transform.SetParent(SceneManager.GetSceneAt(1).GetRootGameObjects()[0].transform);
             GameObject obj = this.inventory.FindFirstObject();
-            currentlySelectedObj.layer = 0;
+
+            Transform[] children = currentlySelectedObj.GetComponentsInChildren<Transform>();
+            foreach (Transform child in children)
+            {
+                child.gameObject.layer = 0;
+            }
+
             if (obj)
             {
                 FindAndSetOutlineMaterialForObj(false, obj, false);
@@ -337,7 +354,13 @@ public class PickupObject : MonoBehaviour
             //This piece of code adds the current item to the room its in instead of keeping it in the hands of the player
             //currentlySelectedObj.gameObject.transform.SetParent(SceneManager.GetSceneAt(1).GetRootGameObjects()[0].transform);
             GameObject obj = this.inventory.FindFirstObject();
-            currentlySelectedObj.layer = 0;
+
+            Transform[] children = currentlySelectedObj.GetComponentsInChildren<Transform>();
+            foreach (Transform child in children)
+            {
+                child.gameObject.layer = 0;
+            }
+
             if (obj)
             {
                 FindAndSetOutlineMaterialForObj(false, obj, false);

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -33,7 +33,7 @@ TagManager:
   - Post Processing
   - Player
   - 
-  - 
+  - ItemsInInventory
   - 
   - 
   - 


### PR DESCRIPTION
Items player carries in their inventory should now all properly display above everything else on the screen.

Note that "Layer #11" is now set to "ItemsInInventory".

"Inventory Camera" and "Main Camera" in "Player" in player_root scene hierarchy have now been set up to work with this.